### PR TITLE
feat: subset tool

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -113,3 +113,231 @@ Please cite our paper if you use LoCoMo in your works:
   year={2024}
 }
 ```
+
+# LOCOMO Dataset Explorer & Subsetter
+
+A comprehensive tool for exploring and intelligently subsetting the LOCOMO dataset for long-term memory evaluation experiments.
+
+## What is this tool?
+
+The LOCOMO dataset contains 10 multi-session conversations between different speaker pairs, with 199 questions per conversation testing various aspects of long-term memory. This tool helps you:
+
+1. **Explore** the dataset to understand conversation structure, question distribution, and temporal relationships
+2. **Subset** the data intelligently by preserving temporal context needed for accurate memory evaluation
+
+## Why do we need this?
+
+The LOCOMO dataset is large and complex. When testing memory models, you need:
+
+- **Temporal context**: All prior conversation history up to a specific point
+- **Category filtering**: Focus on specific types of reasoning (multi-hop, temporal, etc.)
+- **Efficient exploration**: Understand the data before committing to experiments
+
+Manual subsetting would be error-prone and miss crucial temporal dependencies.
+
+## Quick Start
+
+### 1. List all available conversations
+```bash
+python3 locomo_tool.py explore --list-conversations
+```
+**Output:**
+```
+Available Conversations:
+==================================================
+ 0: Caroline ↔ Melanie
+ 1: Jon ↔ Gina
+ 2: John ↔ Maria
+ 3: Joanna ↔ Nate
+ 4: Tim ↔ John
+ 5: Audrey ↔ Andrew
+ 6: James ↔ John
+ 7: Deborah ↔ Jolene
+ 8: Evan ↔ Sam
+ 9: Calvin ↔ Dave
+```
+
+### 2. Deep dive into a conversation
+```bash
+python3 locomo_tool.py explore --conversation 0
+```
+**Shows you:**
+- Session timeline with message counts
+- Question distribution by category
+- Category breakdown per session
+- Sample questions from each category
+
+### 3. Preview a subset before creating it
+```bash
+python3 locomo_tool.py explore --conversation 0 --category 1 --n 10 --preview
+```
+**Shows you:**
+- Which questions would be selected
+- How much conversation history would be included
+- Total message count in the resulting subset
+
+### 4. Create an actual subset for your experiment
+```bash
+python3 locomo_tool.py subset --conversation 0 --category 1 --n 10 --output my_experiment.json
+```
+**Creates:** A clean JSON file ready for ingestion into your memory evaluation pipeline.
+
+## Understanding Categories
+
+Based on the evaluation logic in `task_eval/evaluation.py`, the categories represent:
+
+- **Category 1**: **Multi-hop reasoning** - Complex questions requiring synthesis across multiple conversation points, evaluated with sub-answer splitting and partial F1 scoring
+- **Category 2**: **Single-hop reasoning** - Direct factual recall questions, evaluated with standard F1 scoring  
+- **Category 3**: **Temporal reasoning** - Time-related questions, evaluated with standard F1 scoring (answers may contain semicolon-separated alternatives)
+- **Category 4**: **Open-domain reasoning** - General knowledge questions within conversational context, evaluated with standard F1 scoring
+- **Category 5**: **Adversarial questions** - Questions designed to test information boundaries, where correct answer is "no information available" or "not mentioned"
+
+## How Temporal Subsetting Works
+
+**The Problem**: Questions reference evidence like `["D2:8", "D4:13"]`, meaning they depend on information from session 2, message 8 AND session 4, message 13.
+
+**The Solution**: 
+1. Find the "latest" evidence across your selected questions (e.g., `D4:13`)
+2. Include ALL conversation content from session 1 up through that point
+3. This preserves the full temporal context needed for accurate evaluation
+
+**Example**: If you select 5 questions from category 1, and the latest evidence is `D4:13`, you get:
+- All of sessions 1, 2, and 3
+- Messages 1-13 from session 4
+- Total: ~71 messages of context
+
+## Common Workflows
+
+### Workflow 1: Explore then Experiment
+```bash
+# 1. See what's available
+python3 locomo_tool.py explore --list-conversations
+
+# 2. Pick a conversation and understand it
+python3 locomo_tool.py explore --conversation 0
+
+# 3. Preview your experiment
+python3 locomo_tool.py explore --conversation 0 --category 1 --n 10 --preview
+
+# 4. Create the subset
+python3 locomo_tool.py subset --conversation 0 --category 1 --n 10 --output experiment_cat1.json
+```
+
+### Workflow 2: Quick Category Comparison
+```bash
+# Compare different categories in the same conversation
+python3 locomo_tool.py explore --conversation 0 --category 1 --n 5 --preview
+python3 locomo_tool.py explore --conversation 0 --category 2 --n 5 --preview
+python3 locomo_tool.py explore --conversation 0 --category 3 --n 5 --preview
+```
+
+### Workflow 3: Multi-Conversation Study
+```bash
+# Create subsets from different conversations for comparison
+python3 locomo_tool.py subset --conversation 0 --category 1 --n 10 --output caroline_melanie.json
+python3 locomo_tool.py subset --conversation 1 --category 1 --n 10 --output jon_gina.json
+python3 locomo_tool.py subset --conversation 2 --category 1 --n 10 --output john_maria.json
+```
+
+## Command Reference
+
+### Explore Mode
+```bash
+python3 locomo_tool.py explore [OPTIONS]
+```
+
+**Options:**
+- `--list-conversations`: Show all 10 speaker pairs
+- `--conversation N`: Analyze conversation N (0-9)
+- `--category N`: Specify category for preview
+- `--n N`: Number of questions (default: 10)
+- `--preview`: Preview subset (requires --conversation and --category)
+- `--data PATH`: Custom dataset path (default: data/locomo10.json)
+
+### Subset Mode
+```bash
+python3 locomo_tool.py subset --conversation N --category N --n N --output FILE
+```
+
+**Required:**
+- `--conversation N`: Which conversation (0-9)
+- `--category N`: Which category to filter by
+- `--output FILE`: Where to save the subset
+
+**Optional:**
+- `--n N`: Number of questions (default: 10)
+- `--data PATH`: Custom dataset path
+
+## Output Format
+
+When you create a subset, you get a JSON file with:
+
+```json
+{
+  "qa": [...],                    // Selected questions
+  "conversation": {               // Temporal conversation subset
+    "speaker_a": "Caroline",
+    "speaker_b": "Melanie",
+    "session_1": [...],          // All messages from included sessions
+    "session_1_date_time": "...",
+    // ... more sessions as needed
+  },
+  "subset_info": {               // Metadata about the subset
+    "original_conversation": 0,
+    "category": 1,
+    "questions_requested": 10,
+    "questions_found": 10,
+    "max_evidence": "D4:13",
+    "sessions_included": [1, 2, 3, 4],
+    "total_messages_included": 71
+  }
+}
+```
+
+## Tips & Best Practices
+
+### 🔍 **Always preview first**
+Use `--preview` to understand what you're getting before creating large subsets.
+
+### 📊 **Understand the data distribution**
+Run conversation analysis to see how questions are distributed across sessions and categories.
+
+### 🎯 **Start small**
+Begin with `--n 5` to get a feel for the data, then scale up.
+
+### 📝 **Document your experiments**
+The `subset_info` field contains metadata about exactly what was included - save this for reproducibility.
+
+### ⚡ **Efficient exploration**
+The tool lazy-loads data and caches conversation info, so multiple explores on the same data are fast.
+
+## Troubleshooting
+
+**Error: "No questions found for category X"**
+- Check which categories exist in your chosen conversation
+- Use `python3 locomo_tool.py explore --conversation N` to see available categories
+
+**Error: "Conversation index X out of range"**
+- Valid conversation indices are 0-9
+- Use `--list-conversations` to see available options
+
+**Large file sizes**
+- The original dataset is 2MB+, subsets will be smaller but still substantial
+- Use smaller `--n` values if you need smaller files
+
+## Architecture Notes
+
+The tool is built with three main components:
+
+- **`EvidenceRef`**: Parses and sorts evidence references (D2:8 format)
+- **`LocomoDataset`**: Handles data loading, analysis, and subsetting logic  
+- **`LocomoExplorer`**: Provides user-friendly exploration interfaces
+
+Key design principles:
+- **DRY**: No code duplication across exploration and subsetting
+- **Efficient**: Lazy loading and caching for large datasets
+- **Temporal accuracy**: Preserves conversation context for valid memory evaluation
+
+---
+
+**Questions?** The tool has comprehensive `--help` for each mode, or check the source code for implementation details.

--- a/locomo_tool.py
+++ b/locomo_tool.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""
+LOCOMO Dataset Explorer and Subsetter Tool
+
+A comprehensive tool for exploring and subsetting the LOCOMO dataset for long-term memory evaluation.
+Supports exploration of conversations, sessions, categories, and intelligent temporal subsetting.
+"""
+
+import json
+import argparse
+import re
+from typing import Dict, List, Tuple, Optional, Set
+from collections import defaultdict, Counter
+from dataclasses import dataclass
+
+
+@dataclass
+class EvidenceRef:
+    """Parsed evidence reference (e.g., 'D2:8' -> session=2, message=8)"""
+    session: int
+    message: int
+    
+    @classmethod
+    def parse(cls, evidence_str: str) -> 'EvidenceRef':
+        """Parse evidence string like 'D2:8' into session and message numbers"""
+        match = re.match(r'D(\d+):(\d+)', evidence_str)
+        if not match:
+            raise ValueError(f"Invalid evidence format: {evidence_str}")
+        return cls(int(match.group(1)), int(match.group(2)))
+    
+    def __lt__(self, other: 'EvidenceRef') -> bool:
+        """Enable sorting by session first, then message"""
+        return (self.session, self.message) < (other.session, other.message)
+
+
+class LocomoDataset:
+    """Efficient loader and analyzer for LOCOMO dataset"""
+    
+    def __init__(self, file_path: str):
+        self.file_path = file_path
+        self._data = None
+        self._conversations_cache = None
+    
+    @property
+    def data(self) -> List[Dict]:
+        """Lazy-load dataset"""
+        if self._data is None:
+            with open(self.file_path, 'r') as f:
+                self._data = json.load(f)
+        return self._data
+    
+    def get_conversation_list(self) -> List[Tuple[int, str, str]]:
+        """Get list of (index, speaker_a, speaker_b) for all conversations"""
+        if self._conversations_cache is None:
+            self._conversations_cache = [
+                (i, conv['conversation']['speaker_a'], conv['conversation']['speaker_b'])
+                for i, conv in enumerate(self.data)
+            ]
+        return self._conversations_cache
+    
+    def get_conversation(self, conv_idx: int) -> Dict:
+        """Get specific conversation by index"""
+        if conv_idx < 0 or conv_idx >= len(self.data):
+            raise ValueError(f"Conversation index {conv_idx} out of range (0-{len(self.data)-1})")
+        return self.data[conv_idx]
+    
+    def extract_sessions(self, conversation: Dict) -> Dict[int, Dict]:
+        """Extract all sessions from a conversation with metadata"""
+        sessions = {}
+        conv_data = conversation['conversation']
+        
+        session_num = 1
+        while f'session_{session_num}' in conv_data:
+            session_key = f'session_{session_num}'
+            datetime_key = f'session_{session_num}_date_time'
+            
+            sessions[session_num] = {
+                'messages': conv_data[session_key],
+                'datetime': conv_data.get(datetime_key, 'Unknown'),
+                'message_count': len(conv_data[session_key]) if conv_data[session_key] else 0
+            }
+            session_num += 1
+        
+        return sessions
+    
+    def analyze_questions_by_category(self, conversation: Dict) -> Dict[str, Dict]:
+        """Analyze question distribution by category and session"""
+        questions = conversation['qa']
+        
+        # Overall category distribution
+        category_counts = Counter(q['category'] for q in questions)
+        
+        # Category distribution by session (based on evidence)
+        session_categories = defaultdict(lambda: defaultdict(int))
+        
+        for question in questions:
+            category = question['category']
+            evidence_refs = [EvidenceRef.parse(ev) for ev in question['evidence']]
+            
+            # Count this question for each session it references
+            sessions_referenced = set(ref.session for ref in evidence_refs)
+            for session in sessions_referenced:
+                session_categories[session][category] += 1
+        
+        return {
+            'overall': dict(category_counts),
+            'by_session': dict(session_categories)
+        }
+    
+    def find_max_evidence(self, questions: List[Dict]) -> Optional[EvidenceRef]:
+        """Find the latest evidence reference across multiple questions"""
+        all_evidence = []
+        
+        for question in questions:
+            for evidence_str in question['evidence']:
+                all_evidence.append(EvidenceRef.parse(evidence_str))
+        
+        return max(all_evidence) if all_evidence else None
+    
+    def create_subset(self, conv_idx: int, category: int, n: int) -> Dict:
+        """Create temporal subset based on category and question count"""
+        conversation = self.get_conversation(conv_idx)
+        
+        # Filter questions by category and take first n
+        category_questions = [q for q in conversation['qa'] if q['category'] == category]
+        selected_questions = category_questions[:n]
+        
+        if not selected_questions:
+            raise ValueError(f"No questions found for category {category}")
+        
+        # Find latest evidence reference
+        max_evidence = self.find_max_evidence(selected_questions)
+        if not max_evidence:
+            raise ValueError("No evidence found in selected questions")
+        
+        # Extract sessions up to the max evidence point
+        sessions = self.extract_sessions(conversation)
+        subset_conversation = {'speaker_a': conversation['conversation']['speaker_a'],
+                             'speaker_b': conversation['conversation']['speaker_b']}
+        
+        # Include all sessions up to and including the target session
+        for session_num in range(1, max_evidence.session + 1):
+            if session_num in sessions:
+                session_data = sessions[session_num]
+                subset_conversation[f'session_{session_num}'] = session_data['messages']
+                subset_conversation[f'session_{session_num}_date_time'] = session_data['datetime']
+                
+                # If this is the target session, truncate at the target message
+                if session_num == max_evidence.session:
+                    messages = session_data['messages']
+                    truncated_messages = []
+                    
+                    for msg in messages:
+                        truncated_messages.append(msg)
+                        # Stop after including the target message
+                        msg_ref = EvidenceRef.parse(msg['dia_id'])
+                        if msg_ref.message >= max_evidence.message:
+                            break
+                    
+                    subset_conversation[f'session_{session_num}'] = truncated_messages
+        
+        return {
+            'qa': selected_questions,
+            'conversation': subset_conversation,
+            'subset_info': {
+                'original_conversation': conv_idx,
+                'category': category,
+                'questions_requested': n,
+                'questions_found': len(selected_questions),
+                'max_evidence': f"D{max_evidence.session}:{max_evidence.message}",
+                'sessions_included': list(range(1, max_evidence.session + 1)),
+                'total_messages_included': sum(
+                    len(subset_conversation[f'session_{i}']) 
+                    for i in range(1, max_evidence.session + 1)
+                    if f'session_{i}' in subset_conversation
+                )
+            }
+        }
+
+
+class LocomoExplorer:
+    """Interactive explorer for LOCOMO dataset"""
+    
+    def __init__(self, dataset: LocomoDataset):
+        self.dataset = dataset
+    
+    def list_conversations(self):
+        """Display all available conversations"""
+        conversations = self.dataset.get_conversation_list()
+        print("Available Conversations:")
+        print("=" * 50)
+        for idx, speaker_a, speaker_b in conversations:
+            print(f"{idx:2d}: {speaker_a} ↔ {speaker_b}")
+        print()
+    
+    def analyze_conversation(self, conv_idx: int):
+        """Deep analysis of a specific conversation"""
+        conversation = self.dataset.get_conversation(conv_idx)
+        conv_list = self.dataset.get_conversation_list()
+        speaker_a, speaker_b = conv_list[conv_idx][1], conv_list[conv_idx][2]
+        
+        print(f"Conversation {conv_idx}: {speaker_a} ↔ {speaker_b}")
+        print("=" * 60)
+        
+        # Session overview
+        sessions = self.dataset.extract_sessions(conversation)
+        print(f"Sessions: {len(sessions)}")
+        for session_num, session_data in sessions.items():
+            print(f"  Session {session_num}: {session_data['message_count']} messages ({session_data['datetime']})")
+        
+        print()
+        
+        # Question analysis
+        print(f"Total Questions: {len(conversation['qa'])}")
+        category_analysis = self.dataset.analyze_questions_by_category(conversation)
+        
+        print("\nQuestions by Category (Overall):")
+        for category, count in sorted(category_analysis['overall'].items()):
+            print(f"  Category {category}: {count} questions")
+        
+        print("\nQuestions by Category per Session:")
+        for session_num in sorted(category_analysis['by_session'].keys()):
+            session_cats = category_analysis['by_session'][session_num]
+            cat_str = ", ".join(f"Cat{cat}:{count}" for cat, count in sorted(session_cats.items()))
+            print(f"  Session {session_num}: {cat_str}")
+        
+        # Sample questions per category
+        print("\nSample Questions by Category:")
+        questions_by_cat = defaultdict(list)
+        for q in conversation['qa']:
+            questions_by_cat[q['category']].append(q)
+        
+        for category in sorted(questions_by_cat.keys()):
+            sample_q = questions_by_cat[category][0]
+            evidence_str = ", ".join(sample_q['evidence'])
+            print(f"  Category {category}: \"{sample_q['question']}\" (Evidence: {evidence_str})")
+        
+        print()
+    
+    def preview_subset(self, conv_idx: int, category: int, n: int):
+        """Preview what a subset would include without creating it"""
+        conversation = self.dataset.get_conversation(conv_idx)
+        conv_list = self.dataset.get_conversation_list()
+        speaker_a, speaker_b = conv_list[conv_idx][1], conv_list[conv_idx][2]
+        
+        # Get category questions
+        category_questions = [q for q in conversation['qa'] if q['category'] == category]
+        selected_questions = category_questions[:n]
+        
+        print(f"Subset Preview: {speaker_a} ↔ {speaker_b} | Category {category} | Top {n} questions")
+        print("=" * 80)
+        
+        if not selected_questions:
+            print(f"❌ No questions found for category {category}")
+            return
+        
+        print(f"✓ Found {len(selected_questions)} questions (requested {n})")
+        
+        # Show selected questions
+        print(f"\nSelected Questions:")
+        for i, q in enumerate(selected_questions, 1):
+            evidence_str = ", ".join(q['evidence'])
+            print(f"  {i:2d}. \"{q['question'][:60]}{'...' if len(q['question']) > 60 else ''}\"")
+            print(f"      Evidence: {evidence_str}")
+        
+        # Calculate what would be included
+        max_evidence = self.dataset.find_max_evidence(selected_questions)
+        if max_evidence:
+            print(f"\nLatest Evidence: D{max_evidence.session}:{max_evidence.message}")
+            
+            sessions = self.dataset.extract_sessions(conversation)
+            print(f"Sessions to include: 1 to {max_evidence.session}")
+            
+            total_messages = 0
+            for session_num in range(1, max_evidence.session + 1):
+                if session_num in sessions:
+                    if session_num < max_evidence.session:
+                        count = sessions[session_num]['message_count']
+                        total_messages += count
+                        print(f"  Session {session_num}: All {count} messages")
+                    else:
+                        # Calculate partial session
+                        count = max_evidence.message
+                        total_messages += count
+                        print(f"  Session {session_num}: First {count} messages")
+            
+            print(f"\nTotal messages in subset: {total_messages}")
+        print()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="LOCOMO Dataset Explorer and Subsetter")
+    subparsers = parser.add_subparsers(dest='mode', help='Operation mode')
+    
+    # Explore mode
+    explore_parser = subparsers.add_parser('explore', help='Explore dataset structure')
+    explore_parser.add_argument('--list-conversations', action='store_true',
+                               help='List all available conversations')
+    explore_parser.add_argument('--conversation', type=int, metavar='N',
+                               help='Analyze specific conversation (0-9)')
+    explore_parser.add_argument('--category', type=int, metavar='N',
+                               help='Category for preview (use with --preview)')
+    explore_parser.add_argument('--n', type=int, default=10, metavar='N',
+                               help='Number of questions (default: 10)')
+    explore_parser.add_argument('--preview', action='store_true',
+                               help='Preview subset (requires --conversation, --category)')
+    
+    # Subset mode
+    subset_parser = subparsers.add_parser('subset', help='Create dataset subset')
+    subset_parser.add_argument('--conversation', type=int, required=True, metavar='N',
+                              help='Conversation index (0-9)')
+    subset_parser.add_argument('--category', type=int, required=True, metavar='N',
+                              help='Category to filter by')
+    subset_parser.add_argument('--n', type=int, default=10, metavar='N',
+                              help='Number of questions to include (default: 10)')
+    subset_parser.add_argument('--output', type=str, required=True, metavar='FILE',
+                              help='Output file for subset')
+    
+    # Common arguments
+    for subparser in [explore_parser, subset_parser]:
+        subparser.add_argument('--data', type=str, default='data/locomo10.json',
+                              help='Path to LOCOMO dataset (default: data/locomo10.json)')
+    
+    args = parser.parse_args()
+    
+    if not args.mode:
+        parser.print_help()
+        return
+    
+    # Load dataset
+    try:
+        dataset = LocomoDataset(args.data)
+        explorer = LocomoExplorer(dataset)
+    except FileNotFoundError:
+        print(f"❌ Error: Dataset file '{args.data}' not found")
+        return
+    except json.JSONDecodeError as e:
+        print(f"❌ Error: Invalid JSON in dataset file: {e}")
+        return
+    
+    # Execute commands
+    try:
+        if args.mode == 'explore':
+            if args.list_conversations:
+                explorer.list_conversations()
+            
+            if args.conversation is not None:
+                if args.preview and args.category is not None:
+                    explorer.preview_subset(args.conversation, args.category, args.n)
+                else:
+                    explorer.analyze_conversation(args.conversation)
+        
+        elif args.mode == 'subset':
+            subset_data = dataset.create_subset(args.conversation, args.category, args.n)
+            
+            with open(args.output, 'w') as f:
+                json.dump(subset_data, f, indent=2)
+            
+            info = subset_data['subset_info']
+            print(f"✓ Subset created: {args.output}")
+            print(f"  Questions: {info['questions_found']}/{info['questions_requested']}")
+            print(f"  Max evidence: {info['max_evidence']}")
+            print(f"  Sessions: {len(info['sessions_included'])}")
+            print(f"  Total messages: {info['total_messages_included']}")
+    
+    except Exception as e:
+        print(f"❌ Error: {e}")
+
+
+if __name__ == '__main__':
+    main() 


### PR DESCRIPTION
looking for a way to iterate faster and be more targeted with the data we ingest so it doesn't take 10 hours. one solid session with claude 4 sonnet in cursor came up with this `locomo_tool.py` script that helps us do that. instructions on how to use are in the readme, but some example outputs:
```console
$ (locomo) ➜  locomo git:(vince/subset-tool) python3 locomo_tool.py explore --list-conversations

Available Conversations:
==================================================
 0: Caroline ↔ Melanie
 1: Jon ↔ Gina
 2: John ↔ Maria
 3: Joanna ↔ Nate
 4: Tim ↔ John
 5: Audrey ↔ Andrew
 6: James ↔ John
 7: Deborah ↔ Jolene
 8: Evan ↔ Sam
 9: Calvin ↔ Dave

$ (locomo) ➜  locomo git:(vince/subset-tool) python3 locomo_tool.py explore --conversation 0 --category 1 --n 5 --preview

Subset Preview: Caroline ↔ Melanie | Category 1 | Top 5 questions
================================================================================
✓ Found 5 questions (requested 5)

Selected Questions:
   1. "What did Caroline research?"
      Evidence: D2:8
   2. "What is Caroline's identity?"
      Evidence: D1:5
   3. "What is Caroline's relationship status?"
      Evidence: D3:13, D2:14
   4. "Where did Caroline move from 4 years ago?"
      Evidence: D3:13, D4:3
   5. "What career path has Caroline decided to persue?"
      Evidence: D4:13, D1:11

Latest Evidence: D4:13
Sessions to include: 1 to 4
  Session 1: All 18 messages
  Session 2: All 17 messages
  Session 3: All 23 messages
  Session 4: First 13 messages

Total messages in subset: 71
```
pretty neat. to subset you'd just run something like `python3 locomo_tool.py subset --conversation 0 --category 1 --n 10 --output experiment_cat1.json` and it'd output something that follows the (super messy) existing data structure so it should work downstream in all the evaluate scripts... just change the data path in e.g., the `evaluate_honcho.sh` script to point to your newly subsetted data file.